### PR TITLE
Recommend Ember Select Light

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,11 @@ The goal of `<XSelect>` is to let you see how it works and style it
 right in your template, rather than passing in a ball of configuration
 or wrapping a hard-coded, inaccessible jQuery plugin.
 
+## Recommended <SelectLight>
+
+This addon contains older Ember patterns and depdendencies.
+While it is still ok to continue using, it is recommended to use the more modern
+[Ember Select Light](https://github.com/ember-a11y/ember-select-light/) addon which has a near drop in API and better support for Octane, Embroider, and Accessibility concerns.
 
 ## Installation
 


### PR DESCRIPTION
Ember X Select has been a great addon for many teams, but has not had updates to dependencies or use patterns in quite some time. From asking in Discord, the concensus for a near drop in replacement is the Ember A11Y team's Ember Select Light.

This PR updates the Readme to point out this replacement.
